### PR TITLE
vm: convert `slurp` and `staticRead` to vmops

### DIFF
--- a/compiler/ast/ast_types.nim
+++ b/compiler/ast/ast_types.nim
@@ -742,7 +742,8 @@ type
     mDefined, mDeclared, mDeclaredInScope, mCompiles, mArrGet, mArrPut, mAsgn,
     mLow, mHigh, mSizeOf, mAlignOf, mOffsetOf, mTypeTrait,
     mIs, mOf, mAddr, mType, mTypeOf,
-    mPlugin, mEcho, mShallowCopy, mSlurp,
+    mPlugin, mEcho, mShallowCopy,
+    mSlurp, # deprecated, remove me
     mStatic,
     mParseExprToAst, mParseStmtToAst, mExpandToAst, mQuoteAst,
     mInc, mDec, mOrd,

--- a/compiler/vm/vm.nim
+++ b/compiler/vm/vm.nim
@@ -2026,6 +2026,7 @@ proc rawExecute(c: var TCtx, pc: var int): YieldReason =
                  heap: addr c.heap,
                  graph: c.graph,
                  config: c.config,
+                 currentModule: c.module,
                  cache: c.cache,
                  idgen: c.idgen))
       of ckDefault:
@@ -2626,10 +2627,7 @@ proc rawExecute(c: var TCtx, pc: var int): YieldReason =
           kind: vmEvtNodeNotASymbol, ast: regs[rb].nimNode))
 
     of opcSlurp:
-      decodeB(akString)
-      checkHandle(regs[rb])
-      regs[ra].strVal = opSlurp($regs[rb].strVal, c.debug[pc],
-                                     c.module, c.config)
+      unreachable("no longer an opcode/magic")
 
     of opcParseExprToAst, opcParseStmtToAst:
       decodeBC(rkNimNode)

--- a/compiler/vm/vm_enums.nim
+++ b/compiler/vm/vm_enums.nim
@@ -117,7 +117,7 @@ type
     opcNccValue, opcNccInc, opcNcsAdd, opcNcsIncl, opcNcsLen, opcNcsAt,
     opcNctPut, opcNctLen, opcNctGet, opcNctHasNext, opcNctNext, opcNodeId,
 
-    opcSlurp,
+    opcSlurp,          ## deprecated to be removed
     opcParseExprToAst,
     opcParseStmtToAst,
     opcNGetLineInfo, opcNSetLineInfo,

--- a/compiler/vm/vmdef.nim
+++ b/compiler/vm/vmdef.nim
@@ -399,6 +399,7 @@ type
     # compiler interfacing:
     graph*: ModuleGraph
     config*: ConfigRef
+    currentModule*: PSym ## module currently being compiled
     cache*: IdentCache
     idgen*: IdGenerator
 

--- a/compiler/vm/vmgen.nim
+++ b/compiler/vm/vmgen.nim
@@ -1907,7 +1907,7 @@ proc genMagic(c: var TCtx; n: CgNode; dest: var TDest; m: TMagic) =
     c.gABx(n, opcNSetType, tmp, c.genTypeInfo(n[1].typ))
     c.gABC(n, opcTypeTrait, dest, tmp)
     c.freeTemp(tmp)
-  of mSlurp: genUnaryABC(c, n, dest, opcSlurp)
+  of mSlurp: unreachable("no longer a magic")
   of mNLen: genUnaryABI(c, n, dest, opcLenSeq, nimNodeFlag)
   of mGetImpl: genUnaryABC(c, n, dest, opcGetImpl)
   of mGetImplTransf: genUnaryABC(c, n, dest, opcGetImplTransf)

--- a/compiler/vm/vmops.nim
+++ b/compiler/vm/vmops.nim
@@ -391,6 +391,14 @@ iterator compileTimeOps*(): Override =
 
   override "stdlib.os.getCurrentCompilerExe", proc (a: VmArgs) {.nimcall.} =
     setResult(a, getAppFilename())
+  
+  # xxx: not really a compile-time query, but runs at compiletime and unlike
+  #      osOps it directly impacts compilation
+  for op in ["stdlib.system.slurp", "stdlib.system.staticRead"]:
+    override op, proc (a: VmArgs) {.nimcall.} =
+      let output = opSlurp(getString(a, 0), a.currentLineInfo, a.currentModule,
+                           a.config)
+      writeResult(output)
 
 iterator gorgeOps*(): Override =
   ## Special operations for executing external programs at compile time.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2570,23 +2570,21 @@ proc `[]=`*[Idx, T](a: var array[Idx, T]; i: BackwardsIndex; x: T) {.inline.} =
 proc `[]=`*(s: var string; i: BackwardsIndex; x: char) {.inline.} =
   s[s.len - int(i)] = x
 
-proc slurp*(filename: string): string {.magic: "Slurp".}
-  ## This is an alias for `staticRead <#staticRead,string>`_.
-  ## to be deprecated, use `staticRead`
-
-proc staticRead*(filename: string): string {.magic: "Slurp".}
-  ## Compile-time `readFile <io.html#readFile,string>`_ proc for easy
-  ## `resource`:idx: embedding:
-  ##
-  ## The maximum file size limit that `staticRead` and `slurp` can read is
-  ## near or equal to the *free* memory of the device you are using to compile.
-  ##
-  ## .. code-block:: Nim
-  ##     const myResource = staticRead"mydatafile.bin"
-  ##
-  ## `slurp <#slurp,string>`_ is an alias for `staticRead`.
-
 when defined(nimskullReworkStaticExec):
+  proc slurp*(filename: string): string {.compileTime,
+    deprecated: "use staticRead".} = discard
+    ## This is an alias for `staticRead <#staticRead,string>`_.
+
+  proc staticRead*(filename: string): string {.compileTime.} = discard
+    ## Compile-time `readFile <io.html#readFile,string>`_ proc for easy
+    ## `resource`:idx: embedding:
+    ##
+    ## The maximum file size limit that `staticRead` and `slurp` can read is
+    ## near or equal to the *free* memory of the device you are using to compile.
+    ##
+    ## .. code-block:: Nim
+    ##     const myResource = staticRead"mydatafile.bin"
+
   proc gorge*(command: string, input = "", cache = ""): string {.
     compileTime, deprecated: "use staticExec".} = discard
     ## This is an alias for `staticExec <#staticExec,string,string,string>`_.
@@ -2620,6 +2618,12 @@ when defined(nimskullReworkStaticExec):
     ## 
     ## Deprecate/Replace with variant that returns the exit code and output
 else:
+  proc slurp*(filename: string): string {.magic: "Slurp".} = discard
+    ## kept for bootstrapping
+
+  proc staticRead*(filename: string): string {.magic: "Slurp".} = discard
+    ## kept for bootstrapping
+
   proc gorge*(command: string, input = "", cache = ""): string {.
     magic: "StaticExec".} = discard
     ## kept for bootstrapping

--- a/tests/vm/tslurp.nim
+++ b/tests/vm/tslurp.nim
@@ -1,4 +1,4 @@
-import os
+import std/os
 
 template getScriptDir(): string =
   parentDir(instantiationInfo(-1, true).filename)


### PR DESCRIPTION
## Summary

Convert `slurp` and `staticRead` in the `system` module from magics to
VM callback operations.

## Details

Removal of the magic requires creating a conditional compilation step,
here `nimskullReworkStaticExec` conditional symbol was resued (see:
`condsym`). Two definitions of `slurp` and `staticRead` now exist, one
with the magic and one without. Without this, bootstrapping would no
longer work.

Also marked `slurp` as deprecated, `staticRead` is a far better name.
The reason for the deprecation is that `slurp` is just not as clear as
`staticRead`.

This change enables future removal of the `mSlurp` magic enum, and
more importantly the `opcSlurp` VM opcode in the near future.

---
<!--- Anything before this section break (`---`) will be used as
the commit message when the PR is merged. -->

## Notes for Reviewers
* follow-on/mirroring the change to `gorge` https://github.com/nim-works/nimskull/pull/878

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
